### PR TITLE
FakePage.WithChildren()

### DIFF
--- a/FakeMaker.Examples/ExampleUnitTests.cs
+++ b/FakeMaker.Examples/ExampleUnitTests.cs
@@ -231,6 +231,35 @@ namespace EPiFakeMaker.Examples
 			// Assert
 			Assert.That(pages.Count(), Is.EqualTo(1));
 		}
+
+		[Test]
+		public void Get_descendants_from_with_children()
+		{
+			// Arrange
+			var root =
+				FakePage.Create("root")
+					.WithChildren(
+						new List<FakePage>
+							{
+								FakePage.Create("AboutUs"),
+								FakePage.Create("News").WithChildren(new List<FakePage>
+										{
+											FakePage.Create("News item 1"), 
+											FakePage.Create("News item 2")
+										}),
+								FakePage.Create("Contact")
+							});
+
+
+			_fake.AddToRepository(root);
+
+			// Act
+			var pages =
+				ExampleFindPagesHelper.GetDescendantsOf(root.Page.ContentLink, _fake.ContentRepository);
+
+			// Assert
+			Assert.That(pages.Count(), Is.EqualTo(5));
+		}
 	}
 
 	public class CustomPageData : PageData

--- a/FakeMaker/FakePage.cs
+++ b/FakeMaker/FakePage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using EPiServer.Core;
 
 namespace EPiFakeMaker
@@ -105,6 +106,13 @@ namespace EPiFakeMaker
 		public virtual FakePage WithContentTypeId(int contentTypeId)
 		{
 			Page.Property["PageTypeID"] = new PropertyNumber(contentTypeId);
+
+			return this;
+		}
+
+		public virtual FakePage WithChildren(IEnumerable<FakePage> children)
+		{
+			children.ToList().ForEach(c => c.ChildOf(this));
 
 			return this;
 		}


### PR DESCRIPTION
A small addition that makes it possible to create a page structure in a single statement, without using variables for intermediate pages. An example is included in a test.
